### PR TITLE
Update compendium tags in manifest file

### DIFF
--- a/module.json
+++ b/module.json
@@ -13,7 +13,7 @@
      }
    ],
    "systems": ["wfrp4e"],
-   "version": "0.1.1",
+   "version": "0.1.2",
    "minimumCoreVersion": "0.7.0",
    "compatibleCoreVersion":"0.7.9",
    "packs": [
@@ -24,7 +24,7 @@
       "entity": "Item",
       "module": "nations-of-mankind-wfrp4e",
       "system": "wfrp4e",
-      "tag": "trapping"
+      "tags": ["trapping"]
     },
     {
       "name": "careers-nom",
@@ -33,7 +33,7 @@
       "entity": "Item",
       "module": "nations-of-mankind-wfrp4e",
       "system": "wfrp4e",
-      "tag" : "career"
+      "tags" : ["career"]
     },
     {
       "name": "bestiary-nom",
@@ -66,7 +66,7 @@
         "entity": "Item",
         "system": "wfrp4e",
         "module": "nations-of-mankind-wfrp4e",
-        "tags": "spell"
+        "tags": ["spell"]
     },
     {
         "name": "talents-nom",
@@ -75,7 +75,7 @@
         "entity": "Item",
         "system": "wfrp4e",
         "module": "nations-of-mankind-wfrp4e",
-        "tags": "Talent"
+        "tags": ["talent"]
     },
     {
         "name": "veterantalents-nom",
@@ -84,7 +84,7 @@
         "entity": "Item",
         "system": "wfrp4e",
         "module": "nations-of-mankind-wfrp4e",
-        "tags": "Talent"
+        "tags": ["talent"]
     },
     {
         "name": "prayers-nom",
@@ -93,9 +93,7 @@
         "entity": "Item",
         "system": "wfrp4e",
         "module": "wfrp4e-core",
-        "tags": [
-            "prayer"
-        ]
+        "tags": ["prayer"]
     }
   ],
   "languages": [


### PR DESCRIPTION
Hi CptIgloo ... I've made a couple of tweaks to the module in anticipation of the next release of the WFRP4e system, which includes a Career Selector. Feel free to merge or reject. 

- Compendium references updated from 'tag' to 'tags' for correct parsing by WFRP4e system. This is necessary for NoM careers to appear in the Career Selector (introduced in WFRP4e 3.6).
- Tag references made lowercase for consistency with official modules.