### PR TITLE
Updated for Foundry v14

### DIFF
--- a/module.json
+++ b/module.json
@@ -12,9 +12,9 @@
       "name": "Seseta"
     }
   ],
-  "url": "https://github.com/Hendar23/nations-of-mankind-wfrp4e",
-  "manifest": "https://raw.githubusercontent.com/Hendar23/nations-of-mankind-wfrp4e/main/module.json",
-  "download": "https://github.com/Hendar23/nations-of-mankind-wfrp4e/archive/refs/heads/main.zip",
+  "url": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e",
+  "manifest": "https://raw.githubusercontent.com/Cpt-Igloo/nations-of-mankind-wfrp4e/main/module.json",
+  "download": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e/archive/refs/heads/main.zip",
   "compatibility": {
     "minimum": "12",
     "verified": "14"

--- a/module.json
+++ b/module.json
@@ -1,8 +1,8 @@
 {
-  "name": "nations-of-mankind-wfrp4e",
+  "id": "nations-of-mankind-wfrp4e",
   "title": "Nations of Mankind [WFRP4]",
   "description": "This module adapts Big Boss' unofficial supplement Nations of Mankind to Foundry VTT's wfrp4e system. It adds several new origins for humans from all across the old world, as well as new careers & talents.",
-  "author": "Seseta, Noober",
+  "version": "1.1.0",
   "authors": [
     {
       "name": "Noober",
@@ -13,17 +13,24 @@
     }
   ],
   "url": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e",
-  "flags": {},
-  "version": "1.1.0",
-  "minimumCoreVersion": "0.8.4",
-  "compatibleCoreVersion": "9",
-  "system": ["wfrp4e"],
+  "manifest": "https://raw.githubusercontent.com/Cpt-Igloo/nations-of-mankind-wfrp4e/main/module.json",
+  "download": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e/archive/refs/heads/main.zip",
+  "compatibility": {
+    "minimum": "12",
+    "verified": "14"
+  },
+  "relationships": {
+    "systems": [
+      {
+        "id": "wfrp4e",
+        "type": "system"
+      }
+    ]
+  },
   "scripts": [
     "/scripts/qualities-nom.js",
     "/scripts/subspecies-nom.js"
   ],
-  "esmodules": [],
-  "styles": [],
   "languages": [
     {
       "lang": "en",
@@ -35,118 +42,72 @@
     {
       "name": "trappings-nom",
       "label": "Trappings (Nations of Mankind)",
-      "path": "packs/trappings-nom.db",
+      "path": "packs/trappings-nom",
       "type": "Item",
-      "module": "nations-of-mankind-wfrp4e",
-      "system": "wfrp4e",
-      "tags": [
-        "trapping"
-      ],
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "careers-nom",
       "label": "Careers (Nations of Mankind)",
-      "path": "packs/careers-nom.db",
+      "path": "packs/careers-nom",
       "type": "Item",
-      "module": "nations-of-mankind-wfrp4e",
-      "system": "wfrp4e",
-      "tags": [
-        "career"
-      ],
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "bestiary-nom",
       "label": "Bestiary (Nations of Mankind)",
-      "path": "packs/bestiary-nom.db",
+      "path": "packs/bestiary-nom",
       "type": "Actor",
-      "module": "nations-of-mankind-wfrp4e",
-      "system": "wfrp4e",
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "journalentries-nom",
       "label": "Nations of Mankind Additional Rules",
-      "path": "packs/journalentries-nom.db",
+      "path": "packs/journalentries-nom",
       "type": "JournalEntry",
-      "module": "nations-of-mankind-wfrp4e",
-      "system": "wfrp4e",
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "careerentries-nom",
       "label": "Nations of Mankind Careers Description",
-      "path": "packs/careerentries-nom.db",
+      "path": "packs/careerentries-nom",
       "type": "JournalEntry",
-      "module": "nations-of-mankind-wfrp4e",
-      "system": "wfrp4e",
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "spells-nom",
       "label": "Spells (Nations of Mankind)",
-      "path": "packs/spells-nom.db",
+      "path": "packs/spells-nom",
       "type": "Item",
-      "system": "wfrp4e",
-      "module": "nations-of-mankind-wfrp4e",
-      "tags": [
-        "spell"
-      ],
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "talents-nom",
       "label": "Talents (Nations of Mankind)",
-      "path": "packs/talents-nom.db",
+      "path": "packs/talents-nom",
       "type": "Item",
-      "system": "wfrp4e",
-      "module": "nations-of-mankind-wfrp4e",
-      "tags": [
-        "talent"
-      ],
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "veterantalents-nom",
       "label": "Veteran Talents (Nations of Mankind)",
-      "path": "packs/vettalents-nom.db",
+      "path": "packs/vettalents-nom",
       "type": "Item",
-      "system": "wfrp4e",
-      "module": "nations-of-mankind-wfrp4e",
-      "tags": [
-        "talent"
-      ],
-      "private": false
+      "system": "wfrp4e"
     },
     {
       "name": "prayers-nom",
       "label": "Prayers (Nations of Mankind)",
-      "path": "./packs/prayers-nom.db",
+      "path": "packs/prayers-nom",
       "type": "Item",
-      "system": "wfrp4e",
-      "module": "wfrp4e-core",
-      "tags": [
-        "prayer"
-      ],
-      "private": false
+      "system": "wfrp4e"
     },
     {
-      "label": "Tables (Nations of Mankind)",
-      "type": "RollTable",
       "name": "tables-nom",
-      "path": "packs/tables-nom.db",
-      "system": "wfrp4e",
-      "module": "nations-of-mankind-wfrp4e"
+      "label": "Tables (Nations of Mankind)",
+      "path": "packs/tables-nom",
+      "type": "RollTable",
+      "system": "wfrp4e"
     }
-  ],
-  "system": [
-    "wfrp4e"
-  ],
-  "dependencies": [],
-  "socket": false,
-  "manifest": "https://raw.githubusercontent.com/Cpt-Igloo/nations-of-mankind-wfrp4e/main/module.json",
-  "download": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e/archive/refs/heads/main.zip",
-  "protected": false,
-  "coreTranslation": false
+  ]
 }

--- a/module.json
+++ b/module.json
@@ -12,9 +12,9 @@
       "name": "Seseta"
     }
   ],
-  "url": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e",
-  "manifest": "https://raw.githubusercontent.com/Cpt-Igloo/nations-of-mankind-wfrp4e/main/module.json",
-  "download": "https://github.com/Cpt-Igloo/nations-of-mankind-wfrp4e/archive/refs/heads/main.zip",
+  "url": "https://github.com/Hendar23/nations-of-mankind-wfrp4e",
+  "manifest": "https://raw.githubusercontent.com/Hendar23/nations-of-mankind-wfrp4e/main/module.json",
+  "download": "https://github.com/Hendar23/nations-of-mankind-wfrp4e/archive/refs/heads/main.zip",
   "compatibility": {
     "minimum": "12",
     "verified": "14"


### PR DESCRIPTION
Updates to comply with Foundry VTT v14

Replaced the legacy `name` field with `id` to meet current Foundry requirements.
Removed deprecated `minimumCoreVersion` and `compatibleCoreVersion` fields, implementing the modern `compatibility` object 
Replaced the legacy system array with the modern `relationships` object to cleanly define the `wfrp4e` dependency.
Removed `.db` extensions from the pack paths to reflect modern formatting, and stripped out redundant or empty fields (e.g., duplicate authors, empty dependency arrays) to keep the manifest clean. 
